### PR TITLE
Add error highlighting

### DIFF
--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -13,7 +13,7 @@ endif
 
 
 " Comment
-syntax region yagpdbccComment start=#\v\{\{%(- +)?\/\*#ms=e-1 end=#\v\*\/%( +-)?\}\}#me=s+1
+syntax region yagpdbccComment start=#\v\{\{%(- +)?\/\*# end=#\v\*\/%( +-)?\}\}#
             \ contains=@Spell fold
     " Inline comments, like {{ print "Hello" /*asdf*/ }}, aren't handled,
     " although I don't think they're implemented yet in Yag either.
@@ -87,14 +87,19 @@ highlight default link yagpdbccIgnore Normal
     " we just link to the Normal highlight.
 
 " Error
-"   Error highlighting should apply to:
+"	Ideas for error highlighting:
 "   - Unclosed parens, brackets, double quotes (must close before the ending `{{`)
 "   - Everything after 2K characters
 "   Use regex for this. Will need DZ.
 syntax match yagpdbccError "\v>\$\w*"
     " Dollar signs directly after end-of-words, like if$myvar.
-    syntax match yagpdbccError "\v\{\{%(Anything without }})\zs\{\{"
+syntax region yagpdbccExpr start=#\v\{\{#ms=e+1 end=#\v\}\}#me=s-1 contains=ALL
+syntax region yagpdbccNestedBraces start=#\v\{\{# end=#\v\}\}# contained
+	" This region only matches inside of the Expr region, ensuring we don't
+	" interfere with other groups, or get false matches on things like
+	" {{"{{"}}.
 highlight default link yagpdbccError Error
+highlight default link yagpdbccNestedBraces Error
     " Nested double braces
 
 " Todo

--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -89,10 +89,12 @@ highlight default link yagpdbccIgnore Normal
 " Error
 "   Error highlighting should apply to:
 "   - Nested double braces
-"   - Any dollar sign preceded by non-whitespace
 "   - Unclosed parens, brackets, double quotes (must close before the ending `{{`)
 "   - Everything after 2K characters
 "   Use regex for this. Will need DZ.
+syntax match yagpdbccError "\v>\$\w*"
+    " Dollar signs directly after end-of-words, like if$myvar.
+highlight default link yagpdbccError Error
 
 " Todo
 syntax keyword yagpdbccTodo TODO FIXME XXX

--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -76,7 +76,6 @@ highlight default link yagpdbccObject Type
 highlight default link yagpdbccField Type
 
 " Special
-"   Any special symbol
 syntax match yagpdbccEscaped "\v\\[nt\"\\]" contained
 highlight default link yagpdbccEscaped Special
 syntax match yagpdbccFormat "\v\%\d?[dfsu\%]" contained
@@ -99,7 +98,6 @@ syntax region yagpdbccNestedBraces start=#\v\{\{# end=#\v\}\}# contained
 	" {{"{{"}}.
 highlight default link yagpdbccError Error
 highlight default link yagpdbccNestedBraces Error
-    " Nested double braces
 
 " Todo
 syntax keyword yagpdbccTodo TODO FIXME XXX

--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -13,10 +13,13 @@ endif
 
 
 " Comment
-syntax region yagpdbccComment start=#\v\{\{%(- +)?\/\*# end=#\v\*\/%( +-)?\}\}#
+syntax region yagpdbccComment start=#\v\{\{%(- +)?\/\*#hs=e-1 end=#\v\*\/%( +-)?\}\}#me=s+1
             \ contains=@Spell fold
     " Inline comments, like {{ print "Hello" /*asdf*/ }}, aren't handled,
     " although I don't think they're implemented yet in Yag either.
+	" Also, this consumes the opening braces (to prevent the yagpdbccExpr
+	" group from matching first), but not the closing braces (to allow the
+	" yagpdbccIgnore group to match).
 highlight default link yagpdbccComment Comment
 
 " Constants: String, Character, Number, Boolean, Float
@@ -87,10 +90,6 @@ highlight default link yagpdbccIgnore Normal
     " we just link to the Normal highlight.
 
 " Error
-"	Ideas for error highlighting:
-"   - Unclosed parens, brackets, double quotes (must close before the ending `{{`)
-"   - Everything after 2K characters
-"   Use regex for this. Will need DZ.
 syntax match yagpdbccError "\v>\$\w*"
     " Dollar signs directly after end-of-words, like if$myvar.
 syntax region yagpdbccExpr start=#\v\{\{#ms=e+1 end=#\v\}\}#me=s-1 contains=ALL

--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -88,13 +88,14 @@ highlight default link yagpdbccIgnore Normal
 
 " Error
 "   Error highlighting should apply to:
-"   - Nested double braces
 "   - Unclosed parens, brackets, double quotes (must close before the ending `{{`)
 "   - Everything after 2K characters
 "   Use regex for this. Will need DZ.
 syntax match yagpdbccError "\v>\$\w*"
     " Dollar signs directly after end-of-words, like if$myvar.
+    syntax match yagpdbccError "\v\{\{%(Anything without }})\zs\{\{"
 highlight default link yagpdbccError Error
+    " Nested double braces
 
 " Todo
 syntax keyword yagpdbccTodo TODO FIXME XXX


### PR DESCRIPTION
This PR adds error highlighting for a few specific error cases. Support for other common issues was attempted, but was too complicated (or apparently impossible) to implement.

Error cases caught:

* **Nested sets of double braces.** This is a relatively common mistake I've seen in the YAGPDB support server, particularly among new programmers. They try to do something like `{{ print "Hello and welcome,", {{.Member.Nick}} }}`, not realizing that the second double-brace set is syntactically incorrect.
* **Variable names containing `$`.** While this is not a particularly common mistake, it's definitely an easy one to catch with regex. Plus, even the best of us occasionally forget a space, yielding something like `if$myVar`.

Error cases attempted:

* **Files longer than 10k characters.**
* **Unclosed parens** (before closing `}}`). This might be doable with enough effort, but it won't be fun. If it really ends up being necessary, that's a problem for future me.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
